### PR TITLE
Interceptors and observers: Added the capability to attach observer objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,55 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+TODO: Write better usage instructions here
+
+1. Configure which client to use in your initializers
+
+```
+if Rails.env.test? # || Rails.env.development?
+  ActionTexter::Client.setup("Test")
+else
+  ActionTexter::Client.setup("Nexmo", "key", "secret")
+end
+```
+
+1. Instantiate an ActionTexter::Message
+
+```
+message = ActionTexter::Message.new(from: "phone number",
+                          to: "phone number",
+                          text: "message contents",
+                          reference: "optional reference")
+```
+
+1. Deliver the message
+
+```
+message.deliver
+```
+
+1. **DO NOT** Instantiate the client and call deliver passing in the message. This breaks the beautiful abstraction
+     of the client selector, and it also means observers and interceptors don't work
+
+1. Set observers or interceptors
+
+```
+class MyInterceptor
+    def delivering_sms(message)
+        # Do something with the message. Modify its contents and return the modified object.
+        # Or return nil / false to cancel the sending
+    end
+end
+
+class MyObserver
+    def delivered_sms(message, response)
+        # Log, or do whatever you want with the fact that an SMS has been sent, and that's the response you got
+    end
+end
+
+ActionTexter.register_interceptor(MyInterceptor.new)
+ActionTexter.register_observer(MyObserver.new)
+```
 
 ## Contributing
 

--- a/lib/action_texter.rb
+++ b/lib/action_texter.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 # Copyright © 2012, 2013, Watu
 
+require "action_texter/action_texter"
 require "action_texter/version"
 require "action_texter/client"
 require "action_texter/message"

--- a/lib/action_texter/action_texter.rb
+++ b/lib/action_texter/action_texter.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-# Copyright © 2012, 2013, Watu
+# Copyright © 2014, 2015, Watu
 
 module ActionTexter
   @@delivery_observers = []

--- a/lib/action_texter/action_texter.rb
+++ b/lib/action_texter/action_texter.rb
@@ -1,0 +1,75 @@
+# encoding: UTF-8
+# Copyright © 2012, 2013, Watu
+
+module ActionTexter
+  @@delivery_observers = []
+  @@delivery_interceptors = []
+
+  # You can register an object to be informed of every SMS that is sent, after it is sent
+  # Your object needs to respond to a single method #delivered_sms(message, response)
+  #    message will be of type ActionTexter::Message
+  #    response will be of type ActionTexter::Response
+  #
+  # @param observer [Object] with a #delivered_sms method that will be called passing in the ActionTexter::Message
+  #   and ActionTexter::Response
+  # @returns the observer added
+  def self.register_observer(observer)
+    unless @@delivery_observers.include?(observer)
+      @@delivery_observers << observer
+    end
+    observer
+  end
+
+  # Unregister the given observer
+  #
+  # @param observer [Object] to unregister
+  # @returns deleted observer
+  def self.unregister_observer(observer)
+    @@delivery_observers.delete(observer)
+  end
+
+  # You can register an object to be given every Message object that will be sent, before it is sent.
+  # This allows you to modify the contents of the message, or even stop it by returning false or nil.
+  #
+  # Your object needs to respond to a single method #delivering_sms(message)
+  # It must return the modified object to be sent instead, or nil
+  #
+  # @param interceptor [Object] with a #delivering_sms method that will be called passing in the ActionTexter::Message
+  # @returns the interceptor added
+  def self.register_interceptor(interceptor)
+    unless @@delivery_interceptors.include?(interceptor)
+      @@delivery_interceptors << interceptor
+    end
+    interceptor
+  end
+
+  # Unregister the given interceptor
+  #
+  # @param interceptor [Object] to unregister
+  # @returns deleted interceptor
+  def self.unregister_interceptor(interceptor)
+    @@delivery_interceptors.delete(interceptor)
+  end
+
+  # Inform all the observers about the SMS being sent
+  #
+  # @param message [ActionTexter::Message] that is being sent
+  # @returns the list of observers
+  def self.inform_observers(message, response)
+    @@delivery_observers.each { |observer| observer.delivered_sms(message, response) }
+  end
+
+
+  # Inform all the interceptors about the SMS being sent. Any interceptor can modify the message or cancel it
+  #
+  # @param message [ActionTexter::Message] that is being sent
+  # @returns the message that must be sent, returned by the last interceptor. This may be nil or false
+  def self.inform_interceptors(message)
+    @@delivery_interceptors.each do |interceptor|
+      message = interceptor.delivering_sms(message)
+      break if message.blank?
+    end
+    message
+  end
+
+end

--- a/lib/action_texter/message.rb
+++ b/lib/action_texter/message.rb
@@ -24,11 +24,17 @@ class ActionTexter::Message
   end
 
   def deliver(client = nil)
+    message = ActionTexter.inform_interceptors(self)
+    return nil if message.blank? # Do not send if one of the interceptors cancelled
+
     client ||= ActionTexter::Client.default
     if client.nil?
       raise "To deliver a message you need to specify a client by parameter to deliver or by ActionTexter::Client.dafault="
     end
-    client.deliver(self)
+
+    response = client.deliver(message)
+    ActionTexter.inform_observers(message, response)
+    response
   end
 
   # @private

--- a/lib/action_texter/version.rb
+++ b/lib/action_texter/version.rb
@@ -2,5 +2,5 @@
 # Copyright © 2012, 2013, Watu
 
 module ActionTexter
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/lib/action_texter/version.rb
+++ b/lib/action_texter/version.rb
@@ -2,5 +2,5 @@
 # Copyright © 2012, 2013, Watu
 
 module ActionTexter
-  VERSION = "0.2.0"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
Interceptors and observers: Added the capability to attach observer objects, which get called after the SMS was sent, and interceptors, which get called before the SMS gets sent and can modify the message or stop its sending altogether. This follows more or less the same patterns as the Mail module in Ruby, or as ActionMailer